### PR TITLE
finished backend navigation on forum category card and screen

### DIFF
--- a/src/screens/Forum/ForumCategoriesScreen.js
+++ b/src/screens/Forum/ForumCategoriesScreen.js
@@ -3,6 +3,7 @@ import {
   ScrollView, Text, View, StyleSheet,
 } from 'react-native';
 import firestore from '@react-native-firebase/firestore';
+import PropTypes from 'prop-types';
 import ForumCategoryCard from './ForumCategoryCard';
 
 const styles = StyleSheet.create({
@@ -12,9 +13,11 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function ForumCategoriesScreen() {
+
+export default function ForumCategoriesScreen({ navigation }) {
   const [errorMessage, setErrorMessage] = useState(null);
   const [forumCategories, setForumCategories] = useState([]);
+
 
   firestore()
     .collection('forum_categories')
@@ -35,11 +38,14 @@ export default function ForumCategoriesScreen() {
             }
             return 0;
           })
-          .map((forum) => (
-            <ForumCategoryCard key={forum.id}>
-              {forum.title}
-            </ForumCategoryCard>
-          )),
+          .map((forum) => {
+            const navigateToSubcategory = () => navigation.navigate('ForumSubcategoryPosts', { categoryID: forum.id });
+            return (
+              <ForumCategoryCard key={forum.id} navigate={navigateToSubcategory}>
+                {forum.title}
+              </ForumCategoryCard>
+            );
+          }),
       );
     })
     .catch((error) => {
@@ -55,3 +61,7 @@ export default function ForumCategoriesScreen() {
     </View>
   );
 }
+
+ForumCategoriesScreen.propTypes = {
+  navigation: PropTypes.shape({ navigate: PropTypes.func }).isRequired,
+};

--- a/src/screens/Forum/ForumCategoryCard.js
+++ b/src/screens/Forum/ForumCategoryCard.js
@@ -19,10 +19,10 @@ const styles = StyleSheet.create({
 });
 
 export default function ForumCategoryCard({
-  children,
+  children, navigate,
 }) {
   return (
-    <TouchableOpacity>
+    <TouchableOpacity onPress={navigate}>
       <View style={styles.container}>
         <Title style={styles.text}>
           {children}
@@ -33,4 +33,5 @@ export default function ForumCategoryCard({
 }
 ForumCategoryCard.propTypes = {
   children: PropTypes.string.isRequired,
+  navigate: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
finished off the backend for navigating between the forum categories screen and the forum subcategory screen.
IMPLEMENTED:
- new prop type for navigation and navigation function
- forum category cards now navigate on press
- pass category id as a navigation parameter when navigating from forum categories to forum subcategories

TO DO:
- add final prop type for category logos