### PR TITLE
Stop infinite rendering of ForumPost

### DIFF
--- a/src/screens/Forum/ForumPost.js
+++ b/src/screens/Forum/ForumPost.js
@@ -39,12 +39,14 @@ export default function ForumPost({
   const [loading, setLoading] = useState(true);
   const [numReplies, setNumReplies] = useState(0);
 
-  firestore().collection('forum_comments').where('postID', '==', postID)
-    .get()
-    .then((querySnapshot) => {
-      setNumReplies(querySnapshot.size);
-      setLoading(false);
-    });
+  useEffect(() => {
+    firestore().collection('forum_comments').where('postID', '==', postID)
+      .get()
+      .then((querySnapshot) => {
+        setNumReplies(querySnapshot.size);
+        setLoading(false);
+      });
+  }, [postID]);
 
   const [name, setName] = useState('Name unset');
   const [isAdmin, setIsAdmin] = useState(false);


### PR DESCRIPTION
This database call was causing an infinite rendering of this component. The reason is this:
- In React, a component will rerender whenever its state changes.
- In the `ForumPost` component, the database fetch for `forum_comments` includes a state change; it calls `setNumReplies` and `setLoading`
- This means every time this fetch happens, the state changes, so the component rerenders, so the fetch happens again, and the state changes again, ...

`useEffect` where the dependency is `postID` should stop this. `postID` is a prop, so it never changes, so this fetch will happen once and only once (when the component mounts).